### PR TITLE
Fix file unable to be opened in "Open File" dialog on Windows, and miscellaneous related behaviours change

### DIFF
--- a/Internal/Core/FileSystem.lua
+++ b/Internal/Core/FileSystem.lua
@@ -217,25 +217,28 @@ function FileSystem.GetDirectoryItems(Directory, Options)
 end
 
 function FileSystem.Exists(Path)
-	local Handle = io.open(Path)
-	if Handle ~= nil then
-		io.close(Handle)
+	if (FileSystem.GetRootDirectory(Path) .. FileSystem.Separator()) == Path then
 		return true
 	else
-		local OS = love.system.getOS()
-		if OS == "Windows" then
-			local OK, Error, Code = os.rename(Path, Path)
-			if OK then
+		local Directory = FileSystem.GetDirectory(Path)
+		local BaseName = FileSystem.GetBaseName(Path)
+		BaseName = string.match(BaseName, "(.+)/") or BaseName
+		local ParentDir = FileSystem.Parent(Directory)
+		local ParentDirItems
+		if (Directory .. FileSystem.Separator()) == Path then
+			-- Check if the directory exists
+			ParentDirItems = GetDirectoryItems(ParentDir, {Files=false,Directories=true})
+		else
+			-- Check if the file Exists
+			ParentDirItems = GetDirectoryItems(ParentDir, {Files=true,Directories=false})
+		end
+		for i = 1, #ParentDirItems do
+			if ParentDirItems[i] == BaseName then
 				return true
-			else
-				if Code == 13 then
-					return true
-				end
 			end
 		end
+		return false
 	end
-
-	return false
 end
 
 function FileSystem.IsDirectory(Path)

--- a/Internal/Core/FileSystem.lua
+++ b/Internal/Core/FileSystem.lua
@@ -242,7 +242,9 @@ function FileSystem.Exists(Path)
 end
 
 function FileSystem.IsDirectory(Path)
-	return FileSystem.Exists(Path .. FileSystem.Separator())
+	local Separator = FileSystem.Separator()
+	Path = (string.sub(Path,#Path,#Path) == Separator) and Path or (Path .. Separator)
+	return FileSystem.Exists(Path)
 end
 
 function FileSystem.Parent(Path)

--- a/Internal/UI/Dialog.lua
+++ b/Internal/UI/Dialog.lua
@@ -506,9 +506,11 @@ function Dialog.FileDialog(Options)
 			FileDialogItem('Item_' .. Index, V, true, Index)
 			Index = Index + 1
 		end
-		for I, V in ipairs(ActiveInstance.Files) do
-			FileDialogItem('Item_' .. Index, V, false, Index)
-			Index = Index + 1
+		if Options.Type ~= 'opendirectory' then
+			for I, V in ipairs(ActiveInstance.Files) do
+				FileDialogItem('Item_' .. Index, V, false, Index)
+				Index = Index + 1
+			end
 		end
 		ListBox.End()
 		LayoutManager.End()

--- a/Internal/UI/Dialog.lua
+++ b/Internal/UI/Dialog.lua
@@ -83,10 +83,11 @@ end
 
 local function PruneResults(Items, DirectoryOnly)
 	local Result = {}
-
+	local Separator = FileSystem.Separator()
 	for I, V in ipairs(Items) do
 		if FileSystem.IsDirectory(V) then
 			if DirectoryOnly then
+				V = (string.sub(V,#V,#V) == Separator) and V or (V .. Separator)
 				insert(Result, V)
 			end
 		else


### PR DESCRIPTION
Tested using `main.lua` on Windows 10 and Android.

Files were regarded as folders to be expanded when OK button pressed, therefore could not be opened in "Open File" dialog on Windows. ( #22 )  
Fixed by rewriting `FileSystem.Exists(...)` (e045c3b) ,  but there are some new issues coming up after this change:
- Since files could be selected in "Open Folder" dialog, pressing OK button would leave `Result.Files` as an empty table, and accessing `Result.Files[1]` would trigger an error: `SlabTest.lua:1061: attempt to concatenate upvalue 'DrawDialog_FileDialog_Result' (a nil value)`. Fixed by hiding file entries in "Open Folder" dialog. (c7e3f99)
- (Edited on Jun 10) After c7e3f99, actions like pressing OK button without selecting any files or folders in "Open Folder" dialog would trigger checking `ActiveInstance.Directory` with `FileSystem.Seperator()` as the last char through `FileSystem.IsDirectory(...)` and thus would trigger an error. Fixed by preventing to add a seperator if there already exists, and letting folders returned by `Result.Files` always end with `FileSystem.Seperator()`. (26c448d)

(Edited on Jun 10) All three types of dialogs should be working fine now. Summary of the changes:
- Crashes are fixed on Windows
- Files are no longer visible in "Open Folder" dialog
- Returned folders always end with `FileSystem.Seperator()`
- Pressing OK button before selecting a file in "Open File" or "Save File" dialog will do nothing