### PR TITLE
[Mouse] Read mouse arguments out of Args table

### DIFF
--- a/Internal/Input/Mouse.lua
+++ b/Internal/Input/Mouse.lua
@@ -117,8 +117,8 @@ local function ProcessEvents()
 	Events = {}
 end
 
-function Mouse.Initialize(Args, TransformPointToSlab)
-	TransformPoint = TransformPointToSlab or TransformPoint
+function Mouse.Initialize(Args)
+	TransformPoint = Args.TransformPointToSlab or TransformPoint
 
 	MouseMovedFn = love.handlers['mousemoved']
 	MousePressedFn = love.handlers['mousepressed']


### PR DESCRIPTION
Fix #20. Related to #80.

5fb76d3 changed the order of arguments from #80, so nothing was ever
passed as TransformPointToSlab. Instead, pass it inside the args table
that probably jives better with how things are done in slab.

The function arg to customize screen to slab coordinates isn't passed
from Slab.Initialize -- it only passes the input table.

Usage with push.lua:

    function love.load(args)
        local function get_push_mouse(x,y)
            local new_x,new_y = push:toGame(x,y)
            if new_x and new_y then
                return new_x,new_y
            end
            return x,y
        end
        local game_width, game_height, window_width, window_height = 320, 240, 1280, 720
        push:setupScreen(game_width, game_height, window_width, window_height)
        args.TransformPointToSlab = get_push_mouse
        Slab.Initialize(args)
    end

    function love.draw()
        push:start()
            Slab.Draw()
        push:finish()
    end

Slab.Initialize is already ensuring that args is not nil. 