### PR TITLE
bump version number to 0.9.0

### DIFF
--- a/API.lua
+++ b/API.lua
@@ -234,7 +234,7 @@ local Slab = {}
 
 -- Slab version numbers.
 local Version_Major = 0
-local Version_Minor = 8
+local Version_Minor = 9
 local Version_Revision = 0
 
 local FrameStatHandle = nil


### PR DESCRIPTION
Your 0.9.0 release still has the old version number