### PR TITLE
rectangles in line mode should be drawn at pixel centers

### DIFF
--- a/Internal/Core/DrawCommands.lua
+++ b/Internal/Core/DrawCommands.lua
@@ -119,7 +119,8 @@ local function DrawRect(Rect)
 	local LineW = love.graphics.getLineWidth()
 	love.graphics.setLineWidth(Rect.LineW)
 	love.graphics.setColor(Rect.Color)
-	love.graphics.rectangle(Rect.Mode, Rect.X, Rect.Y, Rect.Width, Rect.Height, Rect.Radius, Rect.Radius)
+	local pixelOffset = Rect.Mode == 'line' and .5 or 0
+	love.graphics.rectangle(Rect.Mode, Rect.X + pixelOffset, Rect.Y + pixelOffset, Rect.Width, Rect.Height, Rect.Radius, Rect.Radius)
 	love.graphics.setLineWidth(LineW)
 
 	Stats.End(StatHandle)


### PR DESCRIPTION
For clean exact edges that look the same everywhere.

Before:
![image](https://user-images.githubusercontent.com/31128870/146806638-af122e43-7ce9-4a05-8af2-1db194ee3d1d.png)

After:
![image](https://user-images.githubusercontent.com/31128870/146806668-5f5b7e6c-9689-4fdc-bc84-f6e59ad80f1e.png)
