### PR TITLE
Enable forwarding input events manually.

### DIFF
--- a/API.lua
+++ b/API.lua
@@ -300,6 +300,19 @@ local function OnQuit()
 end
 
 --[[
+	Event forwarding
+--]]
+
+Slab.OnTextInput = TextInput;
+Slab.OnWheelMoved = WheelMoved;
+Slab.OnQuit = OnQuit;
+Slab.OnKeyPressed = Keyboard.OnKeyPressed;
+Slab.OnKeyReleased = Keyboard.OnKeyReleased;
+Slab.OnMouseMoved = Mouse.OnMouseMoved
+Slab.OnMousePressed = Mouse.OnMousePressed;
+Slab.OnMouseReleased = Mouse.OnMouseReleased;
+
+--[[
 	Initialize
 
 	Initializes Slab and hooks into the required events. This function should be called in love.load.
@@ -311,20 +324,12 @@ end
 
 	Return: None.
 --]]
-function Slab.Initialize(args)
+function Slab.Initialize(args, dontInterceptEventHandlers)
 	if Initialized then
 		return
 	end
 
 	Style.API.Initialize()
-	love.handlers['textinput'] = TextInput
-	love.handlers['wheelmoved'] = WheelMoved
-
-	-- In Love 11.3, overriding love.handlers['quit'] doesn't seem to affect the callback during shutdown.
-	-- Storing and overriding love.quit manually will properly call Slab's callback. This function will call
-	-- the stored function once Slab is finished with its process.
-	QuitFn = love.quit
-	love.quit = OnQuit
 
 	args = args or {}
 	if type(args) == 'table' then
@@ -337,8 +342,19 @@ function Slab.Initialize(args)
 		end
 	end
 
-	Keyboard.Initialize(args)
-	Mouse.Initialize(args)
+	if not dontInterceptEventHandlers then
+		love.handlers['textinput'] = TextInput
+		love.handlers['wheelmoved'] = WheelMoved
+
+		-- In Love 11.3, overriding love.handlers['quit'] doesn't seem to affect the callback during shutdown.
+		-- Storing and overriding love.quit manually will properly call Slab's callback. This function will call
+		-- the stored function once Slab is finished with its process.
+		QuitFn = love.quit
+		love.quit = OnQuit
+	end
+
+	Keyboard.Initialize(args, dontInterceptEventHandlers)
+	Mouse.Initialize(args, dontInterceptEventHandlers)
 
 	LoadState()
 

--- a/Internal/Input/Keyboard.lua
+++ b/Internal/Input/Keyboard.lua
@@ -93,11 +93,16 @@ local function ProcessEvents()
 	Events = NextEvents
 end
 
-function Keyboard.Initialize(Args)
-	KeyPressedFn = love.handlers['keypressed']
-	KeyReleasedFn = love.handlers['keyreleased']
-	love.handlers['keypressed'] = OnKeyPressed
-	love.handlers['keyreleased'] = OnKeyReleased
+Keyboard.OnKeyPressed = OnKeyPressed;
+Keyboard.OnKeyReleased = OnKeyReleased;
+
+function Keyboard.Initialize(Args, dontInterceptEventHandlers)
+	if not dontInterceptEventHandlers then
+		KeyPressedFn = love.handlers['keypressed']
+		KeyReleasedFn = love.handlers['keyreleased']
+		love.handlers['keypressed'] = OnKeyPressed
+		love.handlers['keyreleased'] = OnKeyReleased
+	end
 end
 
 function Keyboard.Update()

--- a/Internal/Input/Mouse.lua
+++ b/Internal/Input/Mouse.lua
@@ -129,15 +129,21 @@ local function ProcessEvents()
 	end
 end
 
-function Mouse.Initialize(Args)
+Mouse.OnMouseMoved = OnMouseMoved;
+Mouse.OnMousePressed = OnMousePressed;
+Mouse.OnMouseReleased = OnMouseReleased;
+
+function Mouse.Initialize(Args, dontInterceptEventHandlers)
 	TransformPoint = Args.TransformPointToSlab or TransformPoint
 
-	MouseMovedFn = love.handlers['mousemoved']
-	MousePressedFn = love.handlers['mousepressed']
-	MouseReleasedFn = love.handlers['mousereleased']
-	love.handlers['mousemoved'] = OnMouseMoved
-	love.handlers['mousepressed'] = OnMousePressed
-	love.handlers['mousereleased'] = OnMouseReleased
+	if not dontInterceptEventHandlers then
+		MouseMovedFn = love.handlers['mousemoved']
+		MousePressedFn = love.handlers['mousepressed']
+		MouseReleasedFn = love.handlers['mousereleased']
+		love.handlers['mousemoved'] = OnMouseMoved
+		love.handlers['mousepressed'] = OnMousePressed
+		love.handlers['mousereleased'] = OnMouseReleased
+	end
 end
 
 function Mouse.Update()

--- a/main.lua
+++ b/main.lua
@@ -27,9 +27,12 @@ SOFTWARE.
 local Slab = require 'Slab'
 local SlabTest = require 'SlabTest'
 
+local dontInterceptEventHandlers = true;
+
 function love.load(args)
 	love.graphics.setBackgroundColor(0.07, 0.07, 0.07)
-	Slab.Initialize(args)
+	Slab.Initialize(args, dontInterceptEventHandlers)
+	if dontInterceptEventHandlers then setCustomHandlers() end
 end
 
 function love.update(dt)
@@ -39,4 +42,47 @@ end
 
 function love.draw()
 	Slab.Draw()
+end
+
+function _quit()
+	Slab.OnQuit()
+end
+
+function _keypressed(key, scancode, isrepeat)
+	Slab.OnKeyPressed(key, scancode, isrepeat)
+end
+
+function _keyreleased(key, scancode)
+	Slab.OnKeyReleased(key, scancode)
+end
+
+function _textinput(text)
+	Slab.OnTextInput(text)
+end
+
+function _wheelmoved(x, y)
+	Slab.OnWheelMoved(x, y)
+end
+
+function _mousemoved(x, y, dx, dy, istouch)
+	Slab.OnMouseMoved(x, y, dx, dy, istouch)
+end
+
+function _mousepressed( x, y, button, istouch, presses)
+	Slab.OnMousePressed( x, y, button, istouch, presses)
+end
+
+function _mousereleased( x, y, button, istouch, presses)
+	Slab.OnMouseReleased( x, y, button, istouch, presses)
+end
+
+function setCustomHandlers()
+	love.handlers['quit'] = _quit;
+	love.handlers['keypressed'] = _keypressed;
+	love.handlers['keyreleased'] = _keyreleased;
+	love.handlers['textinput'] = _textinput;
+	love.handlers['mousemoved'] = _mousemoved;
+	love.handlers['mousepressed'] = _mousepressed;
+	love.handlers['mousereleased'] = _mousereleased;
+	love.handlers['wheelmoved'] = _wheelmoved;
 end


### PR DESCRIPTION
Enable forwarding events manually and option to not intercept event handlers by Slab. It can be usefull if handlers are altered by other code for some reason.