### PR TITLE
Tree crash fix

### DIFF
--- a/Internal/UI/Tree.lua
+++ b/Internal/UI/Tree.lua
@@ -164,7 +164,7 @@ function Tree.Begin(Id, Options)
 	end
 
 	local IsExpanderClicked = false
-    local ExpandIconOptions = Instance.ExpandIconOptions
+	local ExpandIconOptions = Instance.ExpandIconOptions
 
 	if not Options.IsLeaf then
 		-- Render the triangle depending on if the tree item is open/closed.

--- a/Internal/UI/Tree.lua
+++ b/Internal/UI/Tree.lua
@@ -164,12 +164,13 @@ function Tree.Begin(Id, Options)
 	end
 
 	local IsExpanderClicked = false
+    local ExpandIconOptions = Instance.ExpandIconOptions
+
 	if not Options.IsLeaf then
 		-- Render the triangle depending on if the tree item is open/closed.
 		local SubX = Instance.IsOpen and 0 or 200
 		local SubY = Instance.IsOpen and 100 or 50
 
-		local ExpandIconOptions = Instance.ExpandIconOptions
 		if not ExpandIconOptions then
 			ExpandIconOptions = {
 				Image = { Path = SLAB_FILE_PATH .. '/Internal/Resources/Textures/Icons.png', SubW = 50, SubH = 50 },


### PR DESCRIPTION
In the SlabTest menu, there is a crash with the Tree:
```
Error

/Internal/UI/Tree.lua:220: attempt to index global 'ExpandIconOptions' (a nil value)

Traceback

[love "callbacks.lua"]:239: in function 'handler'
/Internal/UI/Tree.lua:220: in function 'BeginTree'
SlabTest.lua:1098: in function <SlabTest.lua:1044>
SlabTest.lua:2532: in function 'Begin'
main.lua:40: in function 'update'
[love "callbacks.lua"]:174: in function <[love "callbacks.lua"]:156>
[C]: in function 'xpcall'
```

The cause of the crash is an out of bound local. This PR fixes that crash