### PR TITLE
Support moving main menu bar slightly

### DIFF
--- a/API.lua
+++ b/API.lua
@@ -768,7 +768,11 @@ end
 	Return: [Boolean] Returns true if the main menu bar process has started.
 --]]
 function Slab.BeginMainMenuBar()
-	Cursor.SetPosition(0.0, 0.0)
+	local X,Y = 0.0, 0.0
+	if Utility.IsMobile() then
+		X, Y = love.window.getSafeArea()
+	end
+	Cursor.SetPosition(X, Y)
 	return Slab.BeginMenuBar(true)
 end
 


### PR DESCRIPTION
The problem: on iOS the default position of the main menu bar is overlapped by the iOS menu bar (time and so on).

So we found it useful to move the main menu bar slightly on iOS.

Please feel free to ignore this PR. I just wanted to share our changes back in case they're useful to you.