### PR TITLE
Return when pressing keypad enter as well

### DIFF
--- a/Internal/UI/Input.lua
+++ b/Internal/UI/Input.lua
@@ -1300,7 +1300,7 @@ function Input.Begin(Id, Options)
 			DragSelect = false
 		end
 
-		if Keyboard.IsPressed('return') then
+		if Keyboard.IsPressed('return') or Keyboard.IsPressed('kpenter') then
 			Result = true
 			if Options.MultiLine then
 				Input.Text('\n')


### PR DESCRIPTION
Very small addition - the enter key on the numpad wasn't being captured, so I've added an IsPressed check for it. I use the numpad very frequently, so it stood out to me when it didn't work as intended.