### PR TITLE
Fix yet another typo in Slab.Input option definition

### DIFF
--- a/SlabDefinition.lua
+++ b/SlabDefinition.lua
@@ -321,7 +321,7 @@ end
 ---@field BgColor? table
 ---@field SelectColor? table
 ---@field SelectOnFocus? boolean
----@field NumberOnly? boolean
+---@field NumbersOnly? boolean
 ---@field W? number
 ---@field H? number
 ---@field ReadOnly? boolean


### PR DESCRIPTION
I'm very sorry for not knowing this typo in the first place 