### PR TITLE
Fixed Docked resizing + added docking restrictor

### DIFF
--- a/Internal/UI/Dock.lua
+++ b/Internal/UI/Dock.lua
@@ -103,7 +103,7 @@ local function DrawOverlay(Type)
 		return
 	end
 
-	-- Проверка DisableDocks у перетаскиваемого окна
+	-- Check DisableDocks for the window being dragged
 	if PendingWindow and PendingWindow.DisableDocks then
 		for _, d in ipairs(PendingWindow.DisableDocks) do
 			if d == Type then

--- a/Internal/UI/Dock.lua
+++ b/Internal/UI/Dock.lua
@@ -103,6 +103,15 @@ local function DrawOverlay(Type)
 		return
 	end
 
+	-- Проверка DisableDocks у перетаскиваемого окна
+	if PendingWindow and PendingWindow.DisableDocks then
+		for _, d in ipairs(PendingWindow.DisableDocks) do
+			if d == Type then
+				return
+			end
+		end
+	end
+
 	local X, Y, W, H = GetOverlayBounds(Type)
 	local Color = {0.29, 0.59, 0.83, 0.65}
 	local TitleH = 14
@@ -183,14 +192,14 @@ function Dock.GetBounds(Type, Options)
 		W = Options.W or 150
 		H = ViewH - Y - TitleH
 	elseif Type == 'Right' then
-		X = ViewW - 150
-		Y = MainMenuBarH
 		W = Options.W or 150
+		X = ViewW - W
+		Y = MainMenuBarH
 		H = ViewH - Y - TitleH
 	elseif Type == 'Bottom' then
-		Y = ViewH - 150
-		W = ViewW
 		H = Options.H or 150
+		Y = ViewH - H
+		W = ViewW
 	end
 
 	return X, Y, W, H
@@ -364,4 +373,3 @@ function Dock.Load(Table)
 end
 
 return Dock
-

--- a/Internal/UI/Window.lua
+++ b/Internal/UI/Window.lua
@@ -600,7 +600,7 @@ function Window.Begin(id, options)
 	end
 
 	ActiveInstance = instance
-	-- Сохраняем DisableDocks в инстансе для доступа из Dock
+	-- Save DisableDocks in the instance to access from Dock
 	if options.DisableDocks then
 		instance.DisableDocks = options.DisableDocks
 	end
@@ -628,7 +628,9 @@ function Window.Begin(id, options)
 	ActiveInstance.H = max(ActiveInstance.SizeDeltaY + h + border, border)
 	ActiveInstance.X = ActiveInstance.TitleDeltaX + x
 	ActiveInstance.Y = ActiveInstance.TitleDeltaY + y
-	-- Жёстко фиксируем позицию для dock-окон
+
+
+	-- Hard-fix position for docked windows
 	if dockType == 'Right' then
 		ActiveInstance.X = Scale.GetScreenWidth() - ActiveInstance.W
 	elseif dockType == 'Bottom' then

--- a/Internal/UI/Window.lua
+++ b/Internal/UI/Window.lua
@@ -533,8 +533,18 @@ function Window.Begin(id, options)
 
 	options = options or EMPTY
 
-	if not Mouse.IsDragging(1) then
+	local instance = GetInstance(id)
+	local dockType = Dock.GetDock(id)
+
+	if not Mouse.IsDragging(1) or dockType then
 		Dock.AlterOptions(id, options)
+		if dockType then
+			if instance.SizerType == 0 then
+				instance.TitleDeltaX = 0
+				instance.TitleDeltaY = 0
+			end
+			options.ResetPosition = false
+		end
 	end
 
 	local x = options.X or 50
@@ -578,7 +588,7 @@ function Window.Begin(id, options)
 		bodyRounding = rounding
 	end
 
-	local instance = GetInstance(id)
+	--local instance = GetInstance(id)
 	insert(PendingStack, 1, instance)
 
 	if options.IsMenuBar then
@@ -590,6 +600,10 @@ function Window.Begin(id, options)
 	end
 
 	ActiveInstance = instance
+	-- Сохраняем DisableDocks в инстансе для доступа из Dock
+	if options.DisableDocks then
+		instance.DisableDocks = options.DisableDocks
+	end
 	if autoSizeWindowW then
 		w = 0
 	end
@@ -610,11 +624,17 @@ function Window.Begin(id, options)
 	if ActiveInstance.Border ~= border then
 		resetSize = true
 	end
-
-	ActiveInstance.X = ActiveInstance.TitleDeltaX + x
-	ActiveInstance.Y = ActiveInstance.TitleDeltaY + y
 	ActiveInstance.W = max(ActiveInstance.SizeDeltaX + w + border, border)
 	ActiveInstance.H = max(ActiveInstance.SizeDeltaY + h + border, border)
+	ActiveInstance.X = ActiveInstance.TitleDeltaX + x
+	ActiveInstance.Y = ActiveInstance.TitleDeltaY + y
+	-- Жёстко фиксируем позицию для dock-окон
+	if dockType == 'Right' then
+		ActiveInstance.X = Scale.GetScreenWidth() - ActiveInstance.W
+	elseif dockType == 'Bottom' then
+		ActiveInstance.Y = Scale.GetScreenHeight() - ActiveInstance.H
+	end
+
 	ActiveInstance.ContentW = contentW
 	ActiveInstance.ContentH = contentH
 	ActiveInstance.BackgroundColor = bgColor


### PR DESCRIPTION
Fix docked window resize behavior and add per-window dock restrictions

- Prevent docked windows from undocking during resize by always
  calling AlterOptions for tethered windows and resetting position
  deltas when resize ends
- Fix Right dock X position recalculation after resize (X = ViewW - W)
- Fix Bottom dock Y position recalculation after resize (Y = ViewH - H)
- Add DisableDocks option to restrict specific dock types per window
  (e.g., DisableDocks = {'Bottom'} prevents docking to bottom edge)