### PR TITLE
Fix four docking bugs: screen-edge overflow, dock/undock flash, and cross-window flicker

### DIFF
--- a/Internal/UI/Dock.lua
+++ b/Internal/UI/Dock.lua
@@ -183,14 +183,20 @@ function Dock.GetBounds(Type, Options)
 		W = Options.W or 150
 		H = ViewH - Y - TitleH
 	elseif Type == 'Right' then
-		X = ViewW - 150
-		Y = MainMenuBarH
+		-- X must be offset by the real W, not a hardcoded 150, or a window
+		-- docked Right wider than 150 overflows off the right edge of the
+		-- screen (its left edge is still anchored at ViewW - 150 while its
+		-- own width extends further than that).
 		W = Options.W or 150
+		X = ViewW - W
+		Y = MainMenuBarH
 		H = ViewH - Y - TitleH
 	elseif Type == 'Bottom' then
-		Y = ViewH - 150
-		W = ViewW
+		-- Same fix, vertically: a window docked Bottom taller than 150
+		-- overflows off the bottom of the screen without this.
 		H = Options.H or 150
+		Y = ViewH - H
+		W = ViewW
 	end
 
 	return X, Y, W, H

--- a/Internal/UI/Dock.lua
+++ b/Internal/UI/Dock.lua
@@ -205,6 +205,28 @@ end
 function Dock.AlterOptions(WinId, Options)
 	Options = Options == nil and {} or Options
 
+	-- A drag-to-dock only becomes official via Dock.Commit(), called from
+	-- Slab.Draw() once the window stops moving -- but Slab.Draw() runs
+	-- AFTER this same frame's widget code (Window.Begin, called from the
+	-- host application's update phase) already built this window's draw
+	-- commands using its OLD (undocked) bounds plus whatever drag offset
+	-- had accumulated. That one-frame lag renders a visible glitch/flash --
+	-- the window jumps to a stale position for exactly one frame -- before
+	-- snapping to the correct docked bounds the frame after (worse the
+	-- further the window was dragged before release). Detect the same
+	-- "mouse just released while hovering a valid dock zone" condition
+	-- Dock.Commit() checks, and commit it here too, so the very same
+	-- Window.Begin call that sees the release also sees the correct dock
+	-- bounds -- Dock.Commit() still runs afterward in Slab.Draw() and just
+	-- harmlessly repeats this assignment.
+	if PendingWindow ~= nil and PendingWindow.Id == WinId and IsValid(Pending) and Mouse.IsReleased(1) then
+		local PendingInstance = GetInstance(Pending)
+		if PendingInstance.Window == nil then
+			PendingInstance.Window = WinId
+			PendingInstance.Reset = true
+		end
+	end
+
 	for Id, Instance in pairs(Instances) do
 		if Instance.Window == WinId then
 

--- a/Internal/UI/Window.lua
+++ b/Internal/UI/Window.lua
@@ -240,8 +240,14 @@ local function UpdateTitleBar(instance, isObstructed, allowMove, constrain)
 
 				if options ~= nil then
 					-- Properly place the window at the mouse position offset by the title width/height.
-					instance.TitleDeltaX = mouseX - x - floor(w * 0.25)
-					instance.TitleDeltaY = mouseY - y - floor(h * 0.5)
+					-- NOTE: TitleDeltaX/Y is added to options.X/Y (the cached, pre-dock bounds this
+					-- window reverts to starting next frame's Window.Begin, now that it's untethered) --
+					-- NOT to x/w/h above, which are this frame's still-docked position/size. Computing
+					-- the delta against x/y instead of options.X/Y makes the window jump back toward its
+					-- old pre-dock position for one frame before subsequent mouse deltas correct it -- a
+					-- visible "flash to the original position" on every tear.
+					instance.TitleDeltaX = mouseX - options.X - floor((options.W or w) * 0.25)
+					instance.TitleDeltaY = mouseY - options.Y - floor((options.H or h) * 0.5)
 				end
 			end
 		end

--- a/Internal/UI/Window.lua
+++ b/Internal/UI/Window.lua
@@ -539,7 +539,18 @@ function Window.Begin(id, options)
 
 	options = options or EMPTY
 
-	if not Mouse.IsDragging(1) then
+	-- Mouse.IsDragging(1) is GLOBAL mouse state (button held + moved), not
+	-- specific to this window -- so guarding AlterOptions on it alone skips
+	-- the dock-bounds recalculation for EVERY window, including docked ones
+	-- that aren't being touched at all, for as long as ANY OTHER window is
+	-- being dragged. A stationary docked window then keeps toggling between
+	-- its correct docked bounds (whenever this happens to be a frame where
+	-- Mouse.HasDelta() is momentarily false) and its raw undocked options
+	-- (options.X/Y/W/H as passed by the caller every frame) otherwise --
+	-- a constant visible flicker on the docked window for the whole
+	-- duration of dragging something else. Only skip AlterOptions for the
+	-- window that is itself the one currently being moved.
+	if not (Mouse.IsDragging(1) and GetInstance(id).IsMoving) then
 		Dock.AlterOptions(id, options)
 	end
 


### PR DESCRIPTION
## Title
Fix four docking bugs: screen-edge overflow, dock/undock flash, and cross-window flicker

## Body

Fixes #178 — four separate bugs in the docking system, found while building an editor tool with two permanently-visible dockable panels. Each is its own commit so they can be reviewed/reverted independently if needed.

1. **`Dock.GetBounds` overflow** — the Right/Bottom screen-edge offset was hardcoded at `150` regardless of the docked window's actual `W`/`H`, so wider/taller windows rendered past the screen edge. Now computes `W`/`H` first and offsets by the real value.
2. **One-frame flash on dock** — `Dock.Commit()` (in `Slab.Draw()`) ran one frame later than the widget code that needed its result, so the window rendered with stale bounds for exactly one frame at the moment of docking. `Dock.AlterOptions` now detects the same commit condition and applies it immediately.
3. **Jump-to-original-position flash on undock** — the tear-completion code computed `TitleDeltaX`/`Y` against the window's current *docked* position, but that value is actually combined with the *cached pre-dock* position next frame — a base mismatch that made every untether jump the window back toward its old spot for one frame. Now computed against the correct (cached) base.
4. **Cross-window flicker** — the guard around calling `Dock.AlterOptions` checked global mouse-drag state instead of whether *this* window was the one being dragged, so a stationary docked window would skip its own bounds recalculation (and briefly fall back to raw un-docked options) for the entire time a *different* window was being dragged — a constant flicker. Now also checks the window's own `IsMoving` flag.

All four confirmed present on `main` at the time of writing (`9b2e3e8`). Tested by hand: dock/undock Left/Right/Bottom with windows of various sizes, drag one docked + one floating window simultaneously, repeated for several minutes with no regressions noticed in resizing, focus, or normal (non-dock) window movement.
